### PR TITLE
Change crate name to mssf-metadata

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,5 +3,5 @@
 version = 3
 
 [[package]]
-name = "fabric-metadata"
-version = "0.1.0"
+name = "mssf-metadata"
+version = "0.0.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,8 +1,19 @@
 [package]
-name = "fabric-metadata"
-version = "0.1.0"
+name = "mssf-metadata"
+description = "mssf-metadata provides linking libs for Microsoft Service Fabric on windows."
+readme = "README.md"
+repository = "https://github.com/Azure/service-fabric-metadata"
+homepage = "https://learn.microsoft.com/en-us/azure/service-fabric/service-fabric-overview"
+documentation = "https://learn.microsoft.com/en-us/azure/service-fabric/"
+version = "0.0.1"
 edition = "2021"
 build = "build.rs"
+license = "MIT"
+include = [
+    "**/*.rs",
+    "importlibs/",
+    "Cargo.toml",
+]
 
 # This is a dummy pkg to host fabric import libs
 # import libs are checkin in /importlibs dir. build.rs will propagate this link search dir


### PR DESCRIPTION
This new crate name is published to crate.io.