### PR TITLE
Fix CMake targets for C++ use.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,6 +17,24 @@ if(fabric_metadata_MAIN_PROJECT)
 endif()
 
 include(cmake/ImportFabric.cmake)
+# add fabric import libs
+set(FABRIC_LIB_NAMES
+  FabricCommon
+  FabricRuntime
+  FabricClient
+  FabricResources
+  FabricServiceCommunication
+  FabricTransport
+)
+
+foreach(_fabric_lib_name ${FABRIC_LIB_NAMES})
+  add_fabric_lib(
+    NAME ${_fabric_lib_name}
+    OUTDIR ${CMAKE_CURRENT_SOURCE_DIR}/importlibs
+    DLLDIR ${ServiceFabric_Runtime_BINARY_DIR}
+  )
+endforeach()
+
 add_subdirectory(src)
 
 if(fabric_metadata_MAIN_PROJECT)
@@ -41,24 +59,6 @@ if(fabric_metadata_MAIN_PROJECT)
     WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/.metadata
     VERBATIM
   )
-
-  # add fabric import libs
-  set(FABRIC_LIB_NAMES
-    FabricCommon
-    FabricRuntime
-    FabricClient
-    FabricResources
-    FabricServiceCommunication
-    FabricTransport
-  )
-
-  foreach(_fabric_lib_name ${FABRIC_LIB_NAMES})
-    add_fabric_lib(
-      NAME ${_fabric_lib_name}
-      OUTDIR ${CMAKE_CURRENT_SOURCE_DIR}/importlibs
-      DLLDIR ${ServiceFabric_Runtime_BINARY_DIR}
-    )
-  endforeach()
 
   add_custom_target(generate_importlibs
     DEPENDS

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,7 +17,7 @@ if(fabric_metadata_MAIN_PROJECT)
 endif()
 
 include(cmake/ImportFabric.cmake)
-# add_subdirectory(src)
+add_subdirectory(src)
 
 if(fabric_metadata_MAIN_PROJECT)
   # generate winmd. defer generation task in .metadata csproj.

--- a/cmake/fetch_get_files.cmake
+++ b/cmake/fetch_get_files.cmake
@@ -41,32 +41,6 @@ foreach(_idl_file ${idl_files})
     list(APPEND out_srcs ${_out_src})
 endforeach()
 
-# static lib that has uuids
-# add_library(fabric_uuids STATIC
-#     ${out_srcs}
-# )
-
-### generate preprocessed header
-### midl generated header has large portion of c defs that is never used by cpp.
-### we generate the headers removing those c defs.
-message(STATUS "fetching coan")
-include(FetchContent)
-FetchContent_Declare(coan
-  URL https://master.dl.sourceforge.net/project/coan2/v6.0.1/coan-6.0.1-x86_64.exe
-  URL_HASH MD5=d2a75c99b45b85e1cfb6e2864395e55b
-  DOWNLOAD_NO_EXTRACT TRUE
-)
-FetchContent_GetProperties(coan)
-if(NOT coan_POPULATED)
-  FetchContent_Populate(coan)
-endif()
-
-find_program(_coan_exe
-    NAMES coan.exe coan-6.0.1-x86_64.exe
-    PATHS ${coan_SOURCE_DIR}
-    REQUIRED
-)
-
 #preprocess headers and write to fabric lib src dir
 set(out_header_cpps "")
 foreach(_header_c ${out_headers})


### PR DESCRIPTION
C++ relies on cmake targets to link with Fabric dlls. For some reason those targets were disabled, and this PR adds them back.