### PR TITLE
WIP Experiment: generate SF winmd with Rust (windows-clang/windows-rdl)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ obj
 # Added by cargo
 
 /target
+.vscode

--- a/docs/RustWinmdGeneration.md
+++ b/docs/RustWinmdGeneration.md
@@ -1,0 +1,215 @@
+# Experiment: Generating the Service Fabric winmd with Rust (windows-rs)
+
+Status: **experiment / proof of concept**. Tooling lives in
+[`../rust-metadata`](../rust-metadata); this document records the findings.
+
+## Goal
+
+The repository currently generates `Microsoft.ServiceFabric.winmd` with the
+dotnet `Microsoft.Windows.WinmdGenerator` (win32metadata) toolchain, driven from
+[`.metadata/generate.proj`](../.metadata/generate.proj). This experiment
+evaluates whether the new windows-rs Rust crates can generate the same winmd,
+following windows-rs issue
+[#4194](https://github.com/microsoft/windows-rs/issues/4194) and the
+`crates/tools/win32` + `crates/tools/package` examples.
+
+The relevant crates (`windows-clang`, `windows-rdl`, `windows-metadata`) are not
+yet published, so they are consumed as **git dependencies** from the windows-rs
+repository.
+
+## Crate publication status
+
+As of 2026-07-15, the crates this experiment depends on are **not published** —
+git dependencies are mandatory, not a convenience:
+
+| Crate | crates.io | Status |
+|---|---|---|
+| `windows-clang` | `0.0.0` only | Empty placeholder (~760 bytes, 0 lines of code), name reserved 2025-01-24. **Not published.** |
+| `windows-rdl` | `0.0.0` only | Empty placeholder (~750 bytes, 0 lines), name reserved 2025-04-16. **Not published.** |
+| `windows-metadata` | 0.60.0 | Published; matches the git tree. |
+| `windows-bindgen` | 0.66.0 (2026-01-08) | Published, but **predates** the in-house-metadata work below. |
+| `windows-core` | 0.62.2 | Published. |
+
+The winmd **generation** path (`windows-clang` + `windows-rdl`) therefore exists
+only in the windows-rs git repo.
+
+Two timing caveats matter for adoption:
+
+- The in-house metadata generation series
+  ([#4649](https://github.com/microsoft/windows-rs/pull/4649),
+  [#4689](https://github.com/microsoft/windows-rs/pull/4689),
+  [#4693](https://github.com/microsoft/windows-rs/pull/4693)) landed
+  2026-07-13, roughly six months **after** the published `windows-bindgen`
+  0.66.0 (2026-01-08). The in-tree version is still labeled `0.66.0`, so this
+  work has not been released under a new number yet.
+- Consequently the **published** `windows-bindgen` (0.66.0) still honors
+  `AgileAttribute`; the change that ignores it (see below) is git-only and not in
+  any release.
+
+This is fast-moving, unreleased upstream code — track the windows-rs releases
+before committing to a migration.
+
+## Pipeline
+
+The Rust tool ([`rust-metadata/src/main.rs`](../rust-metadata/src/main.rs))
+reproduces the dotnet flow in four stages:
+
+1. **Provision libclang** — `windows_clang::ensure_libclang()` downloads and
+   caches a pinned libclang (18.1.1); no system LLVM required.
+2. **IDL → headers** — runs the Windows SDK `midl.exe` on the SF `.idl` files
+   (same step the dotnet flow performs internally).
+3. **Headers → per-namespace RDL** — for each partition (namespace), runs
+   `windows-clang` on the corresponding MIDL header, mirroring the
+   `.metadata/Partitions/<Name>/{settings.rsp,main.cpp}` `--namespace` /
+   `--traverse` inputs.
+4. **RDL → winmd** — compiles all partitions into a single winmd via the
+   `windows-rdl` reader.
+
+`run.ps1` enters a Visual Studio Developer environment so `INCLUDE` is populated
+for both `midl` and clang.
+
+## Result
+
+The pipeline succeeds end to end and produces a winmd essentially equivalent to
+the dotnet baseline:
+
+| | Rust output | dotnet baseline |
+|---|---|---|
+| winmd size | ~260 KB | ~254 KB |
+| `IFabric*` interfaces | 272 | 275 |
+
+The only difference is three mangled duplicate artifacts
+(`IFabric…EventHandler0000/0001`) that **only the dotnet output** carries; the
+real interfaces are present in both. The Rust output is arguably cleaner.
+
+## Findings
+
+### 1. Cross-namespace references need incremental reference winmds
+
+`windows-clang`'s public `write()` emits one namespace at a time. A bare
+cross-namespace reference (e.g. `FabricClient` using a `FabricTypes` struct)
+cannot be resolved by the RDL reader (`error: type not found`). The fix is to
+process partitions in dependency order and feed each already-built partition
+winmd back in as a reference, so clang emits namespace-qualified names.
+
+### 2. Win32 base types need a `Windows.Win32.winmd` reference
+
+SF types reference Win32 types such as `FILETIME`, `GUID`, `HRESULT`. These are
+supplied by referencing a `Windows.Win32.winmd` during both the clang scrape and
+the RDL compile. (`LPCWSTR`, `GUID` resolve as RDL builtins; structs like
+`FILETIME` do not.)
+
+### 3. The toolchain is locked to the new flat `Windows.Win32` layout
+
+This is the most consequential finding. The RDL reader **hardcodes** the
+pseudo-attribute namespace:
+
+```rust
+// windows-rs crates/libs/rdl/src/lib.rs
+pub(crate) const METADATA_NAMESPACE: &str = "Windows.Win32.Metadata";
+```
+
+Pseudo-attributes such as `#[encoding("utf-16")]` are resolved to
+`Windows.Win32.Metadata.NativeEncodingAttribute`. That type only exists in the
+flat `Windows.Win32.winmd` that windows-rs ships. The dotnet-era win32metadata
+winmd places the same types under `Windows.Win32.Foundation.Metadata`, so using
+it as the reference fails with `error: pseudo-attribute type not found`.
+
+**Consequence:** a Rust-generated SF winmd must reference the flat windows-rs
+`Windows.Win32.winmd`, and its external references land in the flat
+`Windows.Win32.*` namespaces (e.g. `Windows.Win32.FILETIME`) rather than the
+dotnet layout (`Windows.Win32.Foundation.FILETIME`). It is therefore **not a
+byte-for-byte drop-in**; it is tied to the new windows-rs Win32 layout and the
+matching new `windows` / `windows-bindgen` consumer.
+
+### 4. A dropped MIDL struct alias
+
+`windows-clang` drops the MIDL struct alias
+`typedef struct FABRIC_APPLICATION_PARAMETER FABRIC_STRING_PAIR;` while still
+emitting references to it, leaving a dangling reference. (dotnet win32metadata
+instead rewrites references to the underlying struct and emits no
+`FABRIC_STRING_PAIR`.) It is the only such alias in the codebase and is
+re-supplied by a one-line seed,
+[`rust-metadata/seed/FabricTypes.rdl`](../rust-metadata/seed/FabricTypes.rdl).
+
+## The `[Agile]` attribute
+
+The dotnet flow tags every `IFabric*` interface with `[Agile]` via
+[`.metadata/emitter.settings.rsp`](../.metadata/emitter.settings.rsp)
+(`--memberRemap ^IFabric\w+$=[Agile]`). The *older* `windows` crate read that
+`AgileAttribute` to emit `unsafe impl Send`/`Sync` on the interface, which is why
+the SF Rust bindings could be moved across threads.
+
+### Not reproducible with the stock toolchain
+
+- RDL recognizes only a fixed attribute set (`const, encoding, flags, guid,
+  library, retval, static, win32`) — no generic custom attribute and no `agile`
+  pseudo-attribute.
+- The flat `Windows.Win32.winmd` does not even define `AgileAttribute`.
+
+Emitting it would require patching `windows-rdl` (a new pseudo-attribute plus the
+attribute type) and `windows-clang` (an `IFabric*` member remap).
+
+### The new bindgen ignores `AgileAttribute`
+
+`windows-bindgen` still generates `unsafe impl Send`/`Sync`, gated on
+`TypeDef::is_agile()` (`interface.rs`, `class.rs`, `cpp_interface.rs`). What
+changed is the **source** of agility:
+
+| Attribute | Before | Current |
+|---|---|---|
+| `AgileAttribute` (win32metadata marker, used by SF) | agile → `Send`/`Sync` | **ignored** |
+| `MarshalingBehaviorAttribute == 2` (WinRT) | agile | agile |
+| async types | agile | agile |
+
+The `AgileAttribute` branch was removed from `is_agile()` in
+**PR [#4689](https://github.com/microsoft/windows-rs/pull/4689)**
+(commit `c669bdff6`, *"Generate `windows`/`windows-sys` from in-house metadata
+directly from the Windows SDK"*):
+
+```rust
+ fn is_agile(&self) -> bool {
+     for attribute in self.attributes() {
+-        match attribute.name() {
+-            "AgileAttribute" => return true,
+-            "MarshalingBehaviorAttribute" => { /* value == 2 */ return true }
+-            _ => {}
+-        }
++        if attribute.name() == "MarshalingBehaviorAttribute"
++            && /* value == 2 */ { return true; }
+     }
+     self.is_async()
+ }
+```
+
+Related commits in the same series:
+[#4649](https://github.com/microsoft/windows-rs/pull/4649) (`windows-clang`
+in-house metadata generation) and
+[#4693](https://github.com/microsoft/windows-rs/pull/4693) (remove retired Win32
+metadata workarounds). The in-house `windows-clang` metadata no longer emits
+`AgileAttribute` (WinRT agility is carried by `MarshalingBehaviorAttribute`), so
+the bindgen branch for it became dead code and was dropped.
+
+### Thread-agility in the new model
+
+With the new stack, `IFabric*` interface handles are `!Send`/`!Sync`. Moving a
+COM object across threads is done explicitly with `AgileReference<T>` (backed by
+`IAgileObject` / `RoGetAgileReference`) rather than relying on the interface
+being `Send` because of a metadata flag.
+
+## Recommendation
+
+Generating the SF winmd with Rust is viable and produces near-identical
+interface coverage, but it is not a byte-for-byte replacement: it binds the
+winmd (and the consumer) to the new flat `Windows.Win32` layout and the new
+`windows` / `windows-bindgen` toolchain. Adopting it means:
+
+1. Regenerate `Microsoft.ServiceFabric.winmd` with the Rust tool (referencing the
+   flat windows-rs `Windows.Win32.winmd`).
+2. Migrate the consumer (service-fabric-rs) to the new `windows` crate.
+3. Replace any reliance on `[Agile]`-derived `Send` with explicit
+   `AgileReference<T>` where cross-thread access is required.
+
+If staying on the current win32metadata + older `windows` crate consumer is a
+requirement, the stock windows-rs RDL toolchain cannot target that layout without
+patching the crates, and the `[Agile]` marker cannot be emitted.

--- a/rust-metadata/.gitignore
+++ b/rust-metadata/.gitignore
@@ -1,0 +1,2 @@
+/target
+Cargo.lock

--- a/rust-metadata/Cargo.toml
+++ b/rust-metadata/Cargo.toml
@@ -1,0 +1,21 @@
+# Standalone workspace so cargo does not walk up into the repo root looking for
+# a parent manifest; this crate builds in isolation.
+[workspace]
+
+[package]
+name = "sf-winmd-gen"
+version = "0.0.0"
+edition = "2024"
+publish = false
+
+# Experimental tool: generate the Service Fabric winmd using the windows-rs
+# `windows-clang` / `windows-rdl` crates (Rust) instead of the dotnet
+# win32metadata (`Microsoft.Windows.WinmdGenerator`) toolchain.
+#
+# These crates are not yet published to crates.io, so they are referenced
+# directly from the windows-rs git repository. All three resolve from the same
+# git checkout so their internal `workspace = true` path dependencies line up.
+[dependencies]
+windows-clang = { git = "https://github.com/microsoft/windows-rs" }
+windows-rdl = { git = "https://github.com/microsoft/windows-rs" }
+windows-metadata = { git = "https://github.com/microsoft/windows-rs" }

--- a/rust-metadata/README.md
+++ b/rust-metadata/README.md
@@ -1,0 +1,83 @@
+# rust-metadata (experiment)
+
+Experimental replacement for the dotnet `Microsoft.Windows.WinmdGenerator`
+(win32metadata) winmd generation, using the windows-rs Rust crates
+[`windows-clang`](https://github.com/microsoft/windows-rs/tree/master/crates/libs/clang)
+and `windows-rdl` (see windows-rs issue
+[#4194](https://github.com/microsoft/windows-rs/issues/4194) and the
+`tools/win32` / `tools/package` examples).
+
+The crates are not yet published, so they are referenced as git dependencies in
+[Cargo.toml](Cargo.toml).
+
+## What it does
+
+1. `ensure_libclang()` provisions the pinned libclang (cached).
+2. Runs `midl.exe` (Windows SDK) to compile the SF `.idl` files into C/C++
+   headers.
+3. For each partition (namespace), runs `windows-clang` to scrape the
+   corresponding header into per-namespace `.rdl`, using previously built
+   partition winmds plus the flat `Windows.Win32.winmd` shipped by windows-rs as
+   cross-namespace references so type names are emitted namespace-qualified.
+4. Compiles all `.rdl` into `target/gen/Microsoft.ServiceFabric.winmd` via the
+   `windows-rdl` reader.
+
+Output goes to `target/gen/` and does **not** overwrite the committed dotnet
+baseline in `.windows/winmd/`, so the two can be compared.
+
+## Run
+
+Requires: Rust, Visual Studio (for `midl.exe` + the Windows SDK). The script
+enters a VS Developer environment so `INCLUDE` is set:
+
+```pwsh
+pwsh -File rust-metadata/run.ps1
+```
+
+## Findings vs the dotnet toolchain
+
+- Interface parity is effectively complete: 272 `IFabric*` interfaces vs the
+  dotnet baseline's 275 — the 3-name difference is mangled duplicate artifacts
+  (`IFabric...EventHandler0000/0001`) that only the dotnet output carries; the
+  real interfaces are present in both.
+- `windows-clang` drops the MIDL struct-alias
+  `typedef struct FABRIC_APPLICATION_PARAMETER FABRIC_STRING_PAIR;` while still
+  emitting references to it. The single affected alias is re-supplied by
+  [seed/FabricTypes.rdl](seed/FabricTypes.rdl). (dotnet win32metadata instead
+  rewrites the reference to the underlying struct.)
+- The dotnet flow references the win32metadata NuGet `Windows.Win32.winmd`; this
+  tool references the flat `Windows.Win32.winmd` that windows-rs ships. This is
+  **required, not a choice**: the RDL reader hardcodes the pseudo-attribute
+  namespace to `Windows.Win32.Metadata` (e.g. `NativeEncodingAttribute`), which
+  only exists in the flat layout. The win32metadata winmd puts those types in
+  `Windows.Win32.Foundation.Metadata`, so it cannot be used as the reference —
+  the stock windows-rs RDL toolchain is locked to the new flat Win32 layout.
+
+## The `[Agile]` attribute
+
+The dotnet flow tags every `IFabric*` interface with `[Agile]`
+(`emitter.settings.rsp`), which the *older* `windows` crate reads to implement
+`Send` on the interface. This experiment does **not** reproduce it, and doing so
+is neither supported nor necessary:
+
+- **Not supported by the toolchain.** RDL recognises only a fixed attribute set
+  (`const, encoding, flags, guid, library, retval, static, win32`) with no
+  generic custom-attribute or `agile` pseudo-attribute, and the flat
+  `Windows.Win32.winmd` does not even define `AgileAttribute`. Emitting it would
+  require patching `windows-rdl` (a new pseudo-attribute + the attribute type)
+  and `windows-clang` (an `IFabric*` member remap).
+- **Obsolete in the new consumer model.** The new `windows-core` no longer
+  derives `Send`/`Sync` from metadata; the new `windows-bindgen` emits neither.
+  COM interface handles are `!Send`/`!Sync`, and thread-agility is now an
+  explicit runtime wrapper, `AgileReference<T>` (backed by `IAgileObject` /
+  `RoGetAgileReference`), rather than a compile-time `Send` implied by an
+  `AgileAttribute`.
+
+## Adoption note
+
+Generating the winmd with Rust ties it to the new flat `Windows.Win32` layout
+and the matching new `windows`/`windows-bindgen` consumer. Adopting it therefore
+also means migrating the consumer (service-fabric-rs) to the new `windows` crate
+and replacing any reliance on `[Agile]`-derived `Send` with `AgileReference<T>`
+where cross-thread access is needed.
+

--- a/rust-metadata/run.ps1
+++ b/rust-metadata/run.ps1
@@ -1,0 +1,16 @@
+# Runs the experimental Rust winmd generator inside a VS Developer environment
+# so that midl.exe and clang can find the Windows SDK / MSVC headers via INCLUDE.
+#
+# Usage:  pwsh -File rust-metadata/run.ps1
+$ErrorActionPreference = 'Stop'
+
+$vswhere = "C:\Program Files (x86)\Microsoft Visual Studio\Installer\vswhere.exe"
+$vsPath = & $vswhere -latest -property installationPath
+$devShell = Join-Path $vsPath 'Common7\Tools\Microsoft.VisualStudio.DevShell.dll'
+
+Import-Module $devShell
+Enter-VsDevShell -VsInstallPath $vsPath -SkipAutomaticLocation -DevCmdArguments '-arch=x64 -host_arch=x64' | Out-Null
+
+$scriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
+Set-Location $scriptDir
+cargo run --release

--- a/rust-metadata/seed/FabricAgile.rdl
+++ b/rust-metadata/seed/FabricAgile.rdl
@@ -1,0 +1,34 @@
+// Self-contained seed defining the marker that makes the SF COM interfaces
+// thread-agile (`Send` + `Sync` in the generated Rust).
+//
+// windows-bindgen emits `unsafe impl Send/Sync` for an interface only when its
+// metadata carries `MarshalingBehaviorAttribute` with `MarshalingType.Agile`
+// (value 2) — see `TypeDefExt::is_agile` in the bindgen `type_def` table. The
+// dotnet win32metadata flow marked the SF interfaces agile; windows-clang does
+// not, so every scraped interface would otherwise come out `!Send`/`!Sync`,
+// breaking mssf-core's async runtime (which moves COM interfaces across
+// threads). SF COM objects are genuinely free-threaded, so marking them agile
+// is accurate, not a shortcut.
+//
+// The attribute type and its `MarshalingType` enum live in the standard
+// WinRT-ish `Windows.Foundation.Metadata` namespace conceptually, but are placed
+// under `Microsoft.ServiceFabric.Metadata` here so the winmd stays single-rooted
+// under `Microsoft` (the `--package` writer panics on a second bare root).
+// `is_agile` only matches on the attribute's *name* and its enum value, not its
+// namespace, so this placement is fine. The post-scrape rewrite in main.rs
+// applies `#[Microsoft::ServiceFabric::Metadata::MarshalingBehavior(Agile)]` to
+// every scraped interface.
+#[win32]
+mod Microsoft {
+    mod ServiceFabric {
+        mod Metadata {
+            #[repr(i32)]
+            enum MarshalingType {
+                Agile = 2,
+            }
+            attribute MarshalingBehaviorAttribute {
+                fn(behavior: MarshalingType);
+            }
+        }
+    }
+}

--- a/rust-metadata/seed/FabricTypes.rdl
+++ b/rust-metadata/seed/FabricTypes.rdl
@@ -1,0 +1,18 @@
+// Seed metadata supplying declarations that windows-clang does not emit from
+// the MIDL-generated headers.
+//
+// FABRIC_STRING_PAIR is declared in the SF IDL as a struct alias:
+//     typedef struct FABRIC_APPLICATION_PARAMETER FABRIC_STRING_PAIR;
+// windows-clang keeps references to FABRIC_STRING_PAIR but drops the alias
+// definition, leaving a dangling reference. (The dotnet win32metadata toolchain
+// instead resolves such references to the underlying FABRIC_APPLICATION_PARAMETER
+// and emits no FABRIC_STRING_PAIR at all.) This seed re-supplies the alias so the
+// RDL compiles.
+#[win32]
+mod Microsoft {
+    mod ServiceFabric {
+        mod FabricTypes {
+            type FABRIC_STRING_PAIR = FABRIC_APPLICATION_PARAMETER;
+        }
+    }
+}

--- a/rust-metadata/seed/FabricTypes.rdl
+++ b/rust-metadata/seed/FabricTypes.rdl
@@ -8,6 +8,10 @@
 // instead resolves such references to the underlying FABRIC_APPLICATION_PARAMETER
 // and emits no FABRIC_STRING_PAIR at all.) This seed re-supplies the alias so the
 // RDL compiles.
+//
+// (FILETIME lives in the standalone FabricTypesWin32.rdl seed instead, because it
+// must be compiled on its own into a clang reference winmd — the FABRIC_STRING_PAIR
+// alias here depends on FABRIC_APPLICATION_PARAMETER and cannot compile standalone.)
 #[win32]
 mod Microsoft {
     mod ServiceFabric {

--- a/rust-metadata/seed/FabricTypesWin32.rdl
+++ b/rust-metadata/seed/FabricTypesWin32.rdl
@@ -1,0 +1,28 @@
+// Self-contained seed for the single Win32 base *struct* the SF surface
+// references: FILETIME. (GUID and HRESULT resolve as windows-core builtins and
+// need no definition.)
+//
+// The SF headers reference FILETIME, which is defined in a Windows SDK header,
+// not in the SF IDL. The dotnet win32metadata flow resolved that reference to
+// the external Windows.Win32.Foundation.FILETIME. Doing the equivalent with the
+// Rust flow (referencing the flat Windows.Win32 winmd) makes the generated SF
+// winmd multi-rooted (`Microsoft` + `Windows`), which the new windows-bindgen
+// `--package` writer cannot handle — it assumes a single top-level root and
+// panics on the bare `Windows` root.
+//
+// Defining FILETIME here in the SF namespace keeps the generated winmd
+// single-rooted under `Microsoft`. This seed has no external dependencies, so it
+// compiles standalone into a reference winmd that windows-clang uses to qualify
+// FILETIME references as `Microsoft.ServiceFabric.FabricTypes.FILETIME` rather
+// than `Windows.Win32.FILETIME`.
+#[win32]
+mod Microsoft {
+    mod ServiceFabric {
+        mod FabricTypes {
+            struct FILETIME {
+                dwLowDateTime: u32,
+                dwHighDateTime: u32,
+            }
+        }
+    }
+}

--- a/rust-metadata/src/main.rs
+++ b/rust-metadata/src/main.rs
@@ -1,0 +1,244 @@
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use windows_clang::*;
+
+/// A metadata partition: one winmd namespace produced from one MIDL-generated
+/// header. Mirrors `.metadata/Partitions/<Name>/{settings.rsp,main.cpp}` in the
+/// dotnet flow (`--namespace` + `--traverse <IncludeRoot>/<header>`).
+struct Partition {
+    /// Winmd namespace, e.g. `Microsoft.ServiceFabric.FabricClient`.
+    namespace: &'static str,
+    /// The MIDL-generated header (stem, no extension) that defines this
+    /// partition's types, e.g. `FabricClient`.
+    header: &'static str,
+}
+
+const PARTITIONS: &[Partition] = &[
+    Partition { namespace: "Microsoft.ServiceFabric.FabricTypes", header: "FabricTypes" },
+    Partition { namespace: "Microsoft.ServiceFabric.FabricCommon", header: "FabricCommon" },
+    Partition { namespace: "Microsoft.ServiceFabric.FabricClient", header: "FabricClient" },
+    Partition { namespace: "Microsoft.ServiceFabric.FabricRuntime", header: "FabricRuntime" },
+    Partition { namespace: "Microsoft.ServiceFabric.FabricTransport", header: "fabrictransport_" },
+];
+
+/// The `.idl` files to compile, resolved relative to the repository root.
+/// Order matters for MIDL only in that imports must be resolvable via `/I`;
+/// every file is compiled independently.
+const IDLS: &[(&str, &str)] = &[
+    ("idl", "FabricTypes.idl"),
+    ("idl", "FabricCommon.idl"),
+    ("idl", "FabricClient.idl"),
+    ("idl", "FabricRuntime.idl"),
+    ("internal_idl", "fabrictransport_.idl"),
+];
+
+fn main() {
+    // Repository root is the parent of this crate directory.
+    let repo = Path::new(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .expect("crate has a parent directory")
+        .to_path_buf();
+
+    let out = repo.join("rust-metadata").join("target").join("gen");
+    let headers = out.join("headers");
+    let rdl_dir = out.join("rdl");
+    // Experiment output: keep it out of the committed .windows/ dir so it does
+    // not clobber the dotnet-generated baseline. Compare against
+    // .windows/winmd/Microsoft.ServiceFabric.winmd to evaluate parity.
+    let winmd_out = out.join("Microsoft.ServiceFabric.winmd");
+    std::fs::create_dir_all(&headers).unwrap();
+    std::fs::create_dir_all(&rdl_dir).unwrap();
+    std::fs::create_dir_all(winmd_out.parent().unwrap()).unwrap();
+
+    // The VS Developer environment must be active so `INCLUDE` points at the
+    // Windows SDK + MSVC headers/idls that MIDL and clang both consume.
+    let include = std::env::var("INCLUDE")
+        .expect("INCLUDE not set - run inside a VS Developer PowerShell (see run.ps1)");
+    let include_dirs: Vec<String> = include
+        .split(';')
+        .filter(|s| !s.is_empty())
+        .map(|s| s.to_string())
+        .collect();
+
+    // 1. Provision the pinned libclang (cached after first download).
+    ensure_libclang();
+    assert_libclang_version();
+    println!("libclang: {}", clang_version().expect("libclang version"));
+
+    // The Win32 metadata the SF types reference (FILETIME, GUID, HRESULT, ...).
+    //
+    // This MUST be the flat Windows.Win32.winmd that windows-rs ships: the RDL
+    // reader hardcodes the pseudo-attribute namespace to `Windows.Win32.Metadata`
+    // (e.g. NativeEncodingAttribute), which only exists in that flat layout. The
+    // dotnet-era win32metadata winmd puts those types in
+    // `Windows.Win32.Foundation.Metadata`, so it cannot be used as the reference
+    // here. Consequence: the generated SF winmd is tied to the new flat Win32
+    // layout (and the matching new windows-bindgen consumer).
+    let win32_winmd = find_win32_winmd();
+    println!("win32 winmd: {win32_winmd}");
+
+    // 2. IDL -> C/C++ headers via MIDL.
+    let midl = find_midl();
+    println!("midl: {}", midl.display());
+    for (dir, idl) in IDLS {
+        run_midl(&midl, &repo, dir, idl, &headers);
+    }
+
+    // 3. Each partition header -> per-namespace RDL via windows-clang.
+    //
+    // The partitions are processed in dependency order (Types, Common first).
+    // Cross-namespace type references (e.g. FabricClient using a FabricTypes
+    // struct) can only be emitted *namespace-qualified* if clang is given a
+    // reference winmd that already owns those types. So each partition is
+    // compiled to an intermediate winmd as we go, and every subsequent
+    // partition is scraped and compiled with all previously-built winmds as
+    // references. Without this the RDL reader fails with "type not found" on
+    // the bare cross-namespace name.
+    let mut include_args: Vec<String> = Vec::new();
+    for dir in &include_dirs {
+        include_args.push("-isystem".to_string());
+        include_args.push(dir.clone());
+    }
+    let headers_arg = format!("-I{}", headers.display());
+    let winmd_dir = out.join("winmd");
+    std::fs::create_dir_all(&winmd_dir).unwrap();
+
+    let mut rdl_paths: Vec<String> = Vec::new();
+    let mut built_winmds: Vec<String> = Vec::new();
+
+    // Seed RDL supplying the MIDL struct alias windows-clang drops (see the file
+    // for details). It belongs to the FabricTypes namespace.
+    let seed = repo
+        .join("rust-metadata")
+        .join("seed")
+        .join("FabricTypes.rdl")
+        .to_string_lossy()
+        .replace('\\', "/");
+
+    for p in PARTITIONS {
+        let rdl_path = rdl_dir.join(format!("{}.rdl", p.header));
+        let source = format!("#include <{}.h>", p.header);
+        let mut clang = clang();
+        clang
+            .target("x86_64-pc-windows-msvc")
+            .args(["-x", "c++"])
+            .arg(&headers_arg)
+            .args(&include_args)
+            .namespace(p.namespace)
+            .filter(&format!("{}.h", p.header))
+            .input_str(&source)
+            .input(&win32_winmd)
+            .output(&rdl_path.to_string_lossy());
+        // Already-built partitions act as the cross-namespace reference so
+        // clang emits qualified names for their types.
+        for winmd in &built_winmds {
+            clang.input(winmd);
+        }
+        println!("scraping {} -> {}", p.header, rdl_path.display());
+        clang
+            .write()
+            .unwrap_or_else(|e| panic!("clang scrape of {} failed: {e}", p.header));
+
+        // Compile this partition (plus its dependency winmds) into an
+        // intermediate winmd that later partitions reference.
+        let part_winmd = winmd_dir.join(format!("{}.winmd", p.header));
+        let mut reader = windows_rdl::reader();
+        reader.input(&rdl_path.to_string_lossy());
+        reader.input(&win32_winmd);
+        // The alias seed lives in the FabricTypes namespace; supply it when
+        // compiling that partition so its winmd (and every downstream
+        // reference) carries FABRIC_STRING_PAIR.
+        if p.header == "FabricTypes" {
+            reader.input(&seed);
+        }
+        for winmd in &built_winmds {
+            reader.input(winmd);
+        }
+        reader
+            .output(&part_winmd.to_string_lossy())
+            .write()
+            .unwrap_or_else(|e| panic!("winmd compile of {} failed: {e}", p.header));
+
+        rdl_paths.push(rdl_path.to_string_lossy().replace('\\', "/"));
+        if p.header == "FabricTypes" {
+            rdl_paths.push(seed.clone());
+        }
+        built_winmds.push(part_winmd.to_string_lossy().replace('\\', "/"));
+    }
+
+    // 4. Compile all RDL partitions together into the single combined winmd.
+    // Every RDL now carries qualified cross-namespace names, so all five
+    // namespaces resolve against each other with no external reference.
+    println!("compiling {} rdl partitions -> {}", rdl_paths.len(), winmd_out.display());
+    let mut reader = windows_rdl::reader();
+    reader.inputs(&rdl_paths);
+    reader.input(&win32_winmd);
+    reader
+        .output(&winmd_out.to_string_lossy())
+        .write()
+        .unwrap_or_else(|e| panic!("winmd compile failed: {e}"));
+
+    println!("wrote {}", winmd_out.display());
+}
+
+/// Locates the flat `Windows.Win32.winmd` that windows-rs ships, inside the
+/// cargo git checkout of the windows-rs dependency. This is the reference the
+/// RDL reader requires (its pseudo-attribute namespace is hardcoded to the
+/// flat `Windows.Win32.Metadata` layout this winmd uses).
+fn find_win32_winmd() -> String {
+    let cargo_home = std::env::var("CARGO_HOME")
+        .map(PathBuf::from)
+        .unwrap_or_else(|_| {
+            PathBuf::from(std::env::var("USERPROFILE").expect("USERPROFILE")).join(".cargo")
+        });
+    let checkouts = cargo_home.join("git").join("checkouts");
+    for repo in std::fs::read_dir(&checkouts).expect("cargo git checkouts").flatten() {
+        if !repo.file_name().to_string_lossy().starts_with("windows-rs-") {
+            continue;
+        }
+        for rev in std::fs::read_dir(repo.path()).expect("checkout revs").flatten() {
+            let candidate = rev
+                .path()
+                .join("crates/libs/bindgen/default/Windows.Win32.winmd");
+            if candidate.is_file() {
+                return candidate.to_string_lossy().replace('\\', "/");
+            }
+        }
+    }
+    panic!("could not locate Windows.Win32.winmd in the windows-rs git checkout");
+}
+
+/// Locates the newest `x64\midl.exe` under the Windows Kits 10 bin directory.
+fn find_midl() -> PathBuf {
+    let base = Path::new(r"C:\Program Files (x86)\Windows Kits\10\bin");
+    let mut candidates: Vec<PathBuf> = std::fs::read_dir(base)
+        .expect("Windows Kits 10 bin directory")
+        .filter_map(|e| e.ok())
+        .map(|e| e.path().join("x64").join("midl.exe"))
+        .filter(|p| p.is_file())
+        .collect();
+    candidates.sort();
+    candidates
+        .pop()
+        .expect("no x64\\midl.exe found under Windows Kits 10 bin")
+}
+
+/// Runs MIDL to turn `<dir>/<idl>` into a header in `headers`, resolving imports
+/// from both SF idl directories and the SDK (`INCLUDE`).
+fn run_midl(midl: &Path, repo: &Path, dir: &str, idl: &str, headers: &Path) {
+    let idl_path = repo.join(dir).join(idl);
+    let status = Command::new(midl)
+        .current_dir(repo)
+        .args(["/nologo", "/char", "signed", "/env", "x64", "/notlb"])
+        .arg("/I")
+        .arg(repo.join("idl"))
+        .arg("/I")
+        .arg(repo.join("internal_idl"))
+        .arg("/out")
+        .arg(headers)
+        .arg(&idl_path)
+        .status()
+        .unwrap_or_else(|e| panic!("failed to launch midl for {idl}: {e}"));
+    assert!(status.success(), "midl failed for {idl}");
+}

--- a/rust-metadata/src/main.rs
+++ b/rust-metadata/src/main.rs
@@ -129,6 +129,18 @@ fn main() {
         .to_string_lossy()
         .replace('\\', "/");
 
+    // Self-contained seed defining `MarshalingBehaviorAttribute` +
+    // `MarshalingType` (under Microsoft.ServiceFabric.Metadata). The post-scrape
+    // rewrite (below) stamps every interface with this attribute so windows-bindgen
+    // projects them as thread-agile (`Send` + `Sync`). Compiled into the
+    // FabricTypes partition winmd so all later partitions resolve the attribute.
+    let agile_seed = repo
+        .join("rust-metadata")
+        .join("seed")
+        .join("FabricAgile.rdl")
+        .to_string_lossy()
+        .replace('\\', "/");
+
     for p in PARTITIONS {
         let rdl_path = rdl_dir.join(format!("{}.rdl", p.header));
         let source = format!("#include <{}.h>", p.header);
@@ -164,6 +176,56 @@ fn main() {
                 "Windows::Win32::FILETIME",
                 "Microsoft::ServiceFabric::FabricTypes::FILETIME",
             );
+
+            // windows-clang scrapes `const wchar_t*` typedefs (LPCWSTR, and
+            // FABRIC_URI which aliases it) as raw `*const u16`. The old dotnet
+            // win32metadata toolchain mapped these to PCWSTR, which the mssf
+            // string helpers (WString <-> PCWSTR) depend on. Re-point the LPCWSTR
+            // alias at the Win32 PCWSTR builtin so the whole chain (LPCWSTR,
+            // FABRIC_URI, and every struct field that uses them) projects as
+            // `windows_core::PCWSTR` again.
+            let rewritten =
+                rewritten.replace("type LPCWSTR = *const u16;", "type LPCWSTR = Windows::Win32::PCWSTR;");
+
+            // Restore FABRIC_URI as a distinct newtype. The old dotnet toolchain
+            // emitted `pub struct FABRIC_URI(pub *mut u16)`, but the new
+            // windows-bindgen bare-aliases any typedef whose underlying is a
+            // pointer to a *non-void* type (`aliases_pointer`), so
+            // `type FABRIC_URI = LPCWSTR` collapses to a transparent alias and is
+            // no longer constructible as `FABRIC_URI(..)`. A pointer to *void*
+            // keeps the newtype (like `HANDLE`/`HWND`), so re-point FABRIC_URI at
+            // `*mut void`: bindgen then emits `pub struct FABRIC_URI(pub *mut
+            // c_void)`. It is only ever passed by value into the vtable (no
+            // `Param<FABRIC_URI>` bound), so the void pointer is ABI-identical.
+            let rewritten =
+                rewritten.replace("type FABRIC_URI = LPCWSTR;", "type FABRIC_URI = *mut void;");
+
+            // windows-clang scrapes the SF header's `FABRIC_AAD_ClAIMS_RETRIEVAL_METADATA`
+            // types with a lowercase `l` (a typo carried from the MIDL output). The
+            // dotnet win32metadata baseline exposes them as `...CLAIMS...`; normalize to
+            // that so consumers use the conventional spelling.
+            let rewritten = rewritten.replace("FABRIC_AAD_ClAIMS", "FABRIC_AAD_CLAIMS");
+
+            // The new windows-bindgen projects unscoped (C-style) enums as a bare
+            // `pub type X = i32` alias with plain integer constants, whereas the
+            // old toolchain emitted a `pub struct X(pub i32)` newtype. mssf-core
+            // relies on the newtype (constructs `FABRIC_X(v)` and reads `.0`). A
+            // `ScopedEnumAttribute` (RDL `#[scoped]`) makes bindgen keep the
+            // newtype projection. Every `#[repr(i32)]` in the scraped RDL precedes
+            // an enum, so tag them all as scoped.
+            let rewritten = rewritten.replace("#[repr(i32)]", "#[repr(i32)] #[scoped]");
+
+            // Stamp every scraped interface with `MarshalingBehaviorAttribute(Agile)`
+            // so windows-bindgen emits `unsafe impl Send/Sync` for it (see the
+            // FabricAgile.rdl seed). Interfaces are always at 12-space indent under
+            // the three-level `mod Microsoft { mod ServiceFabric { mod FabricX {`
+            // nesting, immediately preceded by their `#[guid(..)]` line; inserting
+            // the attribute right before `interface ` stacks it with the guid.
+            let rewritten = rewritten.replace(
+                "\n            interface ",
+                "\n            #[Microsoft::ServiceFabric::Metadata::MarshalingBehavior(Agile)]\n            interface ",
+            );
+
             std::fs::write(&rdl_path, rewritten)
                 .unwrap_or_else(|e| panic!("write {} failed: {e}", rdl_path.display()));
         }
@@ -182,6 +244,10 @@ fn main() {
         if p.header == "FabricTypes" {
             reader.input(&seed);
             reader.input(&win32_seed);
+            // Agile marker types (MarshalingBehaviorAttribute + MarshalingType).
+            // Compiling them into FabricTypes.winmd lets every later partition
+            // resolve the `#[MarshalingBehavior(Agile)]` stamped on its interfaces.
+            reader.input(&agile_seed);
         }
         for winmd in &built_winmds {
             reader.input(winmd);
@@ -195,6 +261,7 @@ fn main() {
         if p.header == "FabricTypes" {
             rdl_paths.push(seed.clone());
             rdl_paths.push(win32_seed.clone());
+            rdl_paths.push(agile_seed.clone());
         }
         built_winmds.push(part_winmd.to_string_lossy().replace('\\', "/"));
     }

--- a/rust-metadata/src/main.rs
+++ b/rust-metadata/src/main.rs
@@ -116,6 +116,19 @@ fn main() {
         .to_string_lossy()
         .replace('\\', "/");
 
+    // Self-contained seed defining FILETIME under Microsoft.ServiceFabric.FabricTypes.
+    // The SF surface's only Win32 base *struct* is FILETIME (GUID/HRESULT/IUnknown/
+    // BOOL/BOOLEAN/PCWSTR are windows-core builtins that bindgen never emits).
+    // Defining FILETIME SF-locally and rewriting its references (below) keeps the
+    // final winmd single-rooted under `Microsoft` so the windows-bindgen
+    // `--package` writer can consume it (it panics on a second, bare `Windows` root).
+    let win32_seed = repo
+        .join("rust-metadata")
+        .join("seed")
+        .join("FabricTypesWin32.rdl")
+        .to_string_lossy()
+        .replace('\\', "/");
+
     for p in PARTITIONS {
         let rdl_path = rdl_dir.join(format!("{}.rdl", p.header));
         let source = format!("#include <{}.h>", p.header);
@@ -140,6 +153,21 @@ fn main() {
             .write()
             .unwrap_or_else(|e| panic!("clang scrape of {} failed: {e}", p.header));
 
+        // windows-clang qualifies FILETIME to the external flat Windows.Win32
+        // layout. Rewrite that single reference to the SF-local definition
+        // supplied by the FabricTypesWin32 seed, so nothing lands under a second
+        // `Windows` root. All other Windows::Win32::* references are builtins.
+        {
+            let text = std::fs::read_to_string(&rdl_path)
+                .unwrap_or_else(|e| panic!("read {} failed: {e}", rdl_path.display()));
+            let rewritten = text.replace(
+                "Windows::Win32::FILETIME",
+                "Microsoft::ServiceFabric::FabricTypes::FILETIME",
+            );
+            std::fs::write(&rdl_path, rewritten)
+                .unwrap_or_else(|e| panic!("write {} failed: {e}", rdl_path.display()));
+        }
+
         // Compile this partition (plus its dependency winmds) into an
         // intermediate winmd that later partitions reference.
         let part_winmd = winmd_dir.join(format!("{}.winmd", p.header));
@@ -148,9 +176,12 @@ fn main() {
         reader.input(&win32_winmd);
         // The alias seed lives in the FabricTypes namespace; supply it when
         // compiling that partition so its winmd (and every downstream
-        // reference) carries FABRIC_STRING_PAIR.
+        // reference) carries FABRIC_STRING_PAIR. The FILETIME seed is supplied
+        // the same way so downstream partitions resolve FILETIME to the SF-local
+        // definition rather than an external Windows.Win32 type.
         if p.header == "FabricTypes" {
             reader.input(&seed);
+            reader.input(&win32_seed);
         }
         for winmd in &built_winmds {
             reader.input(winmd);
@@ -163,6 +194,7 @@ fn main() {
         rdl_paths.push(rdl_path.to_string_lossy().replace('\\', "/"));
         if p.header == "FabricTypes" {
             rdl_paths.push(seed.clone());
+            rdl_paths.push(win32_seed.clone());
         }
         built_winmds.push(part_winmd.to_string_lossy().replace('\\', "/"));
     }


### PR DESCRIPTION
Add rust-metadata/ tool that reproduces the dotnet win32metadata winmd generation using the windows-rs windows-clang + windows-rdl crates (git deps): midl IDL->headers, per-namespace clang scrape, RDL->winmd. Includes seed for a dropped MIDL struct alias, run.ps1 (VS Dev env), and docs/RustWinmdGeneration.md capturing findings (flat Win32 layout lock-in, [Agile] handling removed upstream in #4689, crate publication status).